### PR TITLE
changed zone transitions

### DIFF
--- a/src/scenes/Game/Game.gd
+++ b/src/scenes/Game/Game.gd
@@ -8,6 +8,7 @@ var _patienceManager := PatienceManager.new()
 var _scoreManager := ScoreManager.new()
 var _level : Level
 
+var _zoneTransitionTweens : Array[Tween] = []
 
 func _ready() -> void:
 	AudioManager.music.play(ResourceIds.MusicId.WindTheme)
@@ -80,6 +81,8 @@ func _onHazardFix(hazard: Types.Element) -> void:
 	var zone = Types.Zone.Left if hazard == Types.Element.Water else Types.Zone.Right
 	_patienceManager.gainPatience(zone)
 
+
+
 func _onPlayerEnteredZone(zone: Types.Zone) -> void:
 	var target_color: Color
 	var music_id : ResourceIds.MusicId
@@ -94,8 +97,14 @@ func _onPlayerEnteredZone(zone: Types.Zone) -> void:
 			music_id = ResourceIds.MusicId.WaterTheme
 			target_color = Color("5a80ab")
 
-	AudioManager.music.crossFadeTo(music_id)
-	var tween = create_tween()
+	if _zoneTransitionTweens.size() > 0:
+		for tween in _zoneTransitionTweens:
+			if tween is Tween: tween.kill()
+		_zoneTransitionTweens = []
+	
+	_zoneTransitionTweens = AudioManager.music.crossFadeTo(music_id)
+	var tween : Tween = create_tween()
 	tween.set_parallel(true)
 	tween.tween_property(_backgroundTextureRect, "modulate", target_color, 0.5).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
 	tween.tween_property(_parallax, "modulate", target_color, 0.5).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+	_zoneTransitionTweens.append(tween)

--- a/src/scenes/Game/Levels/TutorialLevel7.tscn
+++ b/src/scenes/Game/Levels/TutorialLevel7.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=4 uid="uid://ccsaiyjgnoe2w"]
+[gd_scene load_steps=27 format=4 uid="uid://c0mml0v1r3d8b"]
 
 [ext_resource type="Script" uid="uid://bnp1d3vki0win" path="res://src/scenes/Game/Levels/Level.gd" id="1_84vmn"]
 [ext_resource type="Script" uid="uid://bd046eokvcnu2" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="2_sjj33"]
@@ -85,7 +85,6 @@ metadata/_custom_type_script = "uid://bhexx6mj1xv3q"
 [node name="Layout" type="Node2D" parent="."]
 
 [node name="DecorationsBack" type="Node2D" parent="Layout"]
-visible = false
 z_index = -1
 
 [node name="Sprite2D5" type="Sprite2D" parent="Layout/DecorationsBack"]
@@ -106,7 +105,6 @@ tile_map_data = PackedByteArray("AAAMAP3/AAABAAIAAAAMAP7/AAABAAMAAAANAP3/AAABAAY
 tile_set = ExtResource("7_n0axo")
 
 [node name="DecorationsFront" type="Node2D" parent="Layout"]
-visible = false
 z_index = -1
 
 [node name="Sprite2D2" type="Sprite2D" parent="Layout/DecorationsFront"]


### PR DESCRIPTION
now tracks the tweens used for transitions and aborts them, ensuring that newer transitions don't get overriden